### PR TITLE
fix setup

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -46,7 +46,6 @@ def rsync_cmd(ssh_key_path, known_hosts_path, target_path, starport):
                                          starport["addr"],
                                          starport["backup_location"])
     args = ["rsync", "-rv", "-e", ssh_cmd, target_path, destination_path]
-    print(args)
     return args
 
 

--- a/backup.py
+++ b/backup.py
@@ -42,7 +42,6 @@ def rsync_cmd(ssh_key_path, known_hosts_path, target_path, starport):
     # -e = specify remote shell program explicitly (i.e. ssh as opposed to the default rsh)
     ssh_cmd = "ssh -o IdentityFile={} -o IdentitiesOnly=yes -o UserKnownHostsFile={}" \
         .format(ssh_key_path, known_hosts_path)
-    print(known_hosts_path)
     destination_path = "{}@{}:{}".format(starport["user"],
                                          starport["addr"],
                                          starport["backup_location"])

--- a/backup.py
+++ b/backup.py
@@ -2,7 +2,7 @@
 import logging
 from datetime import date
 from os import makedirs
-from os.path import join, isdir, abspath, expanduser
+from os.path import join, isdir, abspath
 from subprocess import Popen, PIPE
 import docker
 
@@ -35,13 +35,18 @@ def with_logging(do):
         exit(-1)
 
 
-def rsync_cmd(ssh_key_path, target_path, starport):
+def rsync_cmd(ssh_key_path, known_hosts_path, target_path, starport):
     # rsync options:
     # -v = verbose - give info about what files are being transferred and a brief summary at the end
     # -r = copy directories recursively
     # -e = specify remote shell program explicitly (i.e. ssh as opposed to the default rsh)
-    args = ["rsync", "-rv", "-e", "ssh -o IdentityFile={} -o IdentitiesOnly=yes".format(ssh_key_path),
-            target_path,"{}@{}:{}".format(starport["user"], starport["addr"], starport["backup_location"])]
+    ssh_cmd = "ssh -o IdentityFile={} -o IdentitiesOnly=yes -o UserKnownHostsFile={}" \
+        .format(ssh_key_path, known_hosts_path)
+    print(known_hosts_path)
+    destination_path = "{}@{}:{}".format(starport["user"],
+                                         starport["addr"],
+                                         starport["backup_location"])
+    args = ["rsync", "-rv", "-e", ssh_cmd, target_path, destination_path]
     print(args)
     return args
 
@@ -59,16 +64,17 @@ def run_cmd_with_logging(cmd):
 
 def run_rsync(settings, path):
     starport = settings.starport
-    cmd = rsync_cmd(abspath(settings.ssh_key_path), path, starport)
+    cmd = rsync_cmd(abspath(settings.ssh_key_path), abspath(settings.known_hosts_path), path, starport)
     run_cmd_with_logging(cmd)
 
 
 def run_rsync_from_container(settings, source_volume):
     starport = settings.starport
     docker_ssh_key_path = "/etc/bb8/id_rsa"
+    docker_known_hosts_path="/root/.ssh/known_hosts"
 
-    cmd = rsync_cmd(docker_ssh_key_path, source_volume, starport)
-    volumes = {expanduser("~/.ssh/known_hosts"): {"bind": "/root/.ssh/known_hosts", "mode": "ro"},
+    cmd = rsync_cmd(docker_ssh_key_path, docker_known_hosts_path, source_volume, starport)
+    volumes = {abspath(settings.known_hosts_path): {"bind": "/root/.ssh/known_hosts", "mode": "ro"},
                abspath(settings.ssh_key_path): {"bind": docker_ssh_key_path, "mode": "ro"},
                source_volume: {"bind": "/{}".format(source_volume), "mode": "ro"}}
 

--- a/settings.py
+++ b/settings.py
@@ -61,8 +61,9 @@ def save_private_key():
 
 
 def save_host_key():
-    ssh_key = get_secret("annex/host_key")
+    host_key = get_secret("annex/host_key")
+    settings = load_settings()
     with open(known_hosts_path, 'a'):  # Create file if does not exist
         pass
     with open(known_hosts_path, 'a') as f:
-        f.write(ssh_key)
+        f.write("{} {}".format(settings.starport["addr"], host_key))

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,6 @@
 import json
 import os
-from os.path import join, isfile, abspath
+from os.path import join, isfile
 from subprocess import check_output
 
 from targets import DirectoryTarget, NamedVolumeTarget
@@ -8,6 +8,7 @@ from targets import DirectoryTarget, NamedVolumeTarget
 root_path = "./etc/"
 config_path = join(root_path, "config.json")
 ssh_key_path = join(root_path, "id_rsa")
+known_hosts_path = join(root_path, "known_hosts")
 
 log_dir = './log/'
 
@@ -19,6 +20,7 @@ class Settings:
 
         self.starport = config["starport"]
         self.ssh_key_path = ssh_key_path
+        self.known_hosts_path = known_hosts_path
         self.directory_targets = list(Settings.parse_directory_target(t) for t in config["directory_targets"])
         self.volume_targets = list(Settings.parse_volume_target(t) for t in config["volume_targets"])
 
@@ -59,7 +61,6 @@ def save_private_key():
 
 
 def save_host_key():
-    known_hosts_path = os.path.expanduser("~/.ssh/known_hosts")
     ssh_key = get_secret("annex/host_key")
     with open(known_hosts_path, 'a'):  # Create file if does not exist
         pass

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,7 @@ if ! id -u bb8 > /dev/null 2>&1; then
     # set bb8 home dir
     mkdir /var/lib/bb8/.ssh
     usermod -m -d /var/lib/bb8 bb8
+    chown -R bb8:bb8 /var/lib/bb8
 
     # add to docker group
     usermod -aG docker bb8

--- a/setup.sh
+++ b/setup.sh
@@ -12,11 +12,10 @@ echo "-------------------------------------------"
 echo "Installing bb8 user and group"
 
 if ! id -u bb8 > /dev/null 2>&1; then
-    useradd bb8 -d /usr/lib/bb8
+    useradd bb8 -d /var/lib/bb8
     password=$(vault read --field password secret/backup/bb8/user)
     echo "bb8:$password" | chpasswd
 
-    # Perhaps defer until python?
     mkdir -p /var/lib/bb8/.ssh
 
     # add to docker group

--- a/setup.sh
+++ b/setup.sh
@@ -1,42 +1,37 @@
 #!/usr/bin/env bash
 set -e
 
-source ${BASH_SOURCE%/*}/vault_auth.sh
+HERE=${BASH_SOURCE%/*}
+source ${HERE}/vault_auth.sh
 
 echo "Installing Pip and required Python packages"
 apt-get install python3-pip -y > /dev/null
-pip3 install -q -r requirements.txt
+pip3 install -q -r ${HERE}/requirements.txt
 
 echo "-------------------------------------------"
 echo "Installing bb8 user and group"
 
 if ! id -u bb8 > /dev/null 2>&1; then
-    useradd bb8
+    useradd bb8 -d /usr/lib/bb8
     password=$(vault read --field password secret/backup/bb8/user)
     echo "bb8:$password" | chpasswd
 
-    # set bb8 home dir
-    mkdir /var/lib/bb8/.ssh
-    usermod -m -d /var/lib/bb8 bb8
-    chown -R bb8:bb8 /var/lib/bb8
+    # Perhaps defer until python?
+    mkdir -p /var/lib/bb8/.ssh
 
     # add to docker group
     usermod -aG docker bb8
-fi
-
-if ! /usr/bin/getent group bb8 2>&1 > /dev/null; then
-    groupadd bb8
 fi
 
 # add bb8 user to bb8 group
 usermod -aG bb8 bb8
 
 # give bb8 group owernship of this dir
-chgrp -R bb8 .
+chgrp -R bb8 $HERE
 
 echo "-------------------------------------------"
 echo "Running setup.py:"
-su -c "source ${BASH_SOURCE%/*}/vault_auth.sh && ${BASH_SOURCE%/*}/setup.py" bb8
+(cd "$HERE" && su -c ./setup.py bb8)
 
 echo "-------------------------------------------"
 

--- a/setup.sh
+++ b/setup.sh
@@ -6,16 +6,38 @@ source ${BASH_SOURCE%/*}/vault_auth.sh
 echo "Installing Pip and required Python packages"
 apt-get install python3-pip -y > /dev/null
 pip3 install -q -r requirements.txt
+
+echo "-------------------------------------------"
+echo "Installing bb8 user and group"
+
 if ! id -u bb8 > /dev/null 2>&1; then
     useradd bb8
     password=$(vault read --field password secret/backup/bb8/user)
     echo "bb8:$password" | chpasswd
+
+    # set bb8 home dir
+    mkdir /var/lib/bb8/.ssh
+    usermod -m -d /var/lib/bb8 bb8
+
+    # add to docker group
+    usermod -aG docker bb8
 fi
+
+if ! /usr/bin/getent group bb8 2>&1 > /dev/null; then
+    groupadd bb8
+fi
+
+# add bb8 user to bb8 group
+usermod -aG bb8 bb8
+
+# give bb8 group owernship of this dir
+chgrp -R bb8 .
 
 echo "-------------------------------------------"
 echo "Running setup.py:"
 su -c "source ${BASH_SOURCE%/*}/vault_auth.sh && ${BASH_SOURCE%/*}/setup.py" bb8
 
 echo "-------------------------------------------"
+
 echo "Setup complete. To schedule backups, run ./schedule.py"
 echo "To perform a restore, run ./restore.py"

--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ echo "-------------------------------------------"
 echo "Installing bb8 user and group"
 
 if ! id -u bb8 > /dev/null 2>&1; then
-    useradd bb8 -d /var/lib/bb8
+    useradd bb8 -U -d /var/lib/bb8
     password=$(vault read --field password secret/backup/bb8/user)
     echo "bb8:$password" | chpasswd
 
@@ -21,9 +21,6 @@ if ! id -u bb8 > /dev/null 2>&1; then
     # add to docker group
     usermod -aG docker bb8
 fi
-
-# add bb8 user to bb8 group
-usermod -aG bb8 bb8
 
 # give bb8 group owernship of this dir
 chgrp -R bb8 $HERE

--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,7 @@ fi
 
 echo "-------------------------------------------"
 echo "Running setup.py:"
-su -c "source ${BASH_SOURCE%/*}/vault_auth.sh && ${BASH_SOURCE%/*}/setup.py bb8"
+su -c "source ${BASH_SOURCE%/*}/vault_auth.sh && ${BASH_SOURCE%/*}/setup.py" bb8
 
 echo "-------------------------------------------"
 echo "Setup complete. To schedule backups, run ./schedule.py"

--- a/setup_starport.sh
+++ b/setup_starport.sh
@@ -16,7 +16,7 @@ trap cleanup EXIT
 ssh-keygen -f $KEY_PATH/id_rsa -q -N ""
 vault write secret/annex/id_rsa value=@$KEY_PATH/id_rsa
 vault write secret/annex/id_rsa.pub value=@$KEY_PATH/id_rsa.pub
-vault write secret/annex/host_key value=@/etc/ssh/ssh_host_rsa_key.pub
+vault write secret/annex/host_key value=@/etc/ssh/ssh_host_ecdsa_key.pub
 
 cat $KEY_PATH/id_rsa.pub >> ~/.ssh/authorized_keys
 

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y \
+        curl \
+        python3 \
+        python3-pip \
+        unzip
+
+RUN curl -L -o vault.zip https://releases.hashicorp.com/vault/0.9.3/vault_0.9.3_linux_amd64.zip && \
+        unzip -d /usr/local/bin vault.zip && \
+        rm -f vault.zip
+
+RUN groupadd docker

--- a/testing/test-setup.sh
+++ b/testing/test-setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -ex
+HERE=${BASH_SOURCE%/*}
+BB8_ROOT=$(readlink -f ${HERE}/..)
+
+if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
+    echo "Variable VAULT_AUTH_GITHUB_TOKEN must be set"
+    exit 1
+fi
+
+IMAGE_NAME=bb8_setup
+
+docker build --rm -t $IMAGE_NAME $HERE
+docker run --rm -v ${BB8_ROOT}:/src \
+       -e VAULT_AUTH_GITHUB_TOKEN=$VAULT_AUTH_GITHUB_TOKEN \
+       $IMAGE_NAME \
+       /src/setup.sh

--- a/vault_auth.sh
+++ b/vault_auth.sh
@@ -6,4 +6,4 @@ if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
     export VAULT_AUTH_GITHUB_TOKEN=${token}
 fi
 echo "Authenticating with the Vault"
-vault auth --method=github > /dev/null
+export VAULT_TOKEN=$(vault auth --method=github --token-only)


### PR DESCRIPTION
Permissions were all messed up. 

`setup.sh` should be run as `sudo` and will create the bb8 user (with home path `/var/lib/bb8`) and bb8 group which is given ownership of the directory so it can write to the `./etc` and `./log` sub-directories.

`backup.py` can then be run by bb8 as intended.

The format of the host key entry in the `known_hosts` file was also wrong. Format fixed and now written to a local file in `./etc` which is explicitly passed to the `ssh` commands.