### PR TITLE
Dockerfile and script for testing the setup works

### DIFF
--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y \
+        curl \
+        python3 \
+        python3-pip \
+        unzip
+
+RUN curl -L -o vault.zip https://releases.hashicorp.com/vault/0.9.3/vault_0.9.3_linux_amd64.zip && \
+        unzip -d /usr/local/bin vault.zip && \
+        rm -f vault.zip
+
+RUN groupadd docker

--- a/testing/test-setup.sh
+++ b/testing/test-setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -ex
+HERE=${BASH_SOURCE%/*}
+BB8_ROOT=$(readlink -f ${HERE}/..)
+
+if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
+    echo "Variable VAULT_AUTH_GITHUB_TOKEN must be set"
+    exit 1
+fi
+
+IMAGE_NAME=bb8_setup
+
+docker build --rm -t $IMAGE_NAME $HERE
+docker run --rm -v ${BB8_ROOT}:/src \
+       -e VAULT_AUTH_GITHUB_TOKEN=$VAULT_AUTH_GITHUB_TOKEN \
+       $IMAGE_NAME \
+       /src/setup.sh


### PR DESCRIPTION
This is to help with the review of #5 rather than dumping everything inline. Aside from the vault issue[*] this would be ok to run on teamcity to ensure that the setup does not regress.

[*]: we should make VAULT_ADDR configurable and then set up a testing vault with the appropriate bits in it.  That would be a good set up the starport setup too