### PR TITLE
i1682: Avoid requiring root where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ or to see all options, just:
 ```
 
 ## Schedule backups
-`schedule.sh`: Creates a cron job that backs up every hour and logs to the 
+`./schedule`: Creates a cron job that backs up every hour and logs to the 
 `bb8_logs` volume. Must be run as root.
 
 # Tests

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ So that bb8 can communicate with the Starport via ssh, we first need to
 generate a key pair which we store in the vault, then add the public key to 
 the authorized_keys file on Starport. This is done by running 
 `./setup_starport.sh` on the Starport. To run backups bb8 needs the  
-corresponding private key and a JSON configuration file. During `setup.sh` these
+corresponding private key and a JSON configuration file. During `setup` these
 are pulled from the vault and stored in the ssh volume.
 
 ## Setup leaf machine
@@ -53,7 +53,7 @@ Note: Montagu specific setup instructions here: https://github.com/vimc/montagu-
 If setting up Montagu backup, follow those instructions first. Then, from this directory:
 
 ```
-./setup.sh PATH_TO_SOURCE_CONFIG [TARGET ...]
+./setup PATH_TO_SOURCE_CONFIG [TARGET ...]
 ```
 
 This builds a new docker image. It includes the source config, filtered to 
@@ -65,16 +65,16 @@ volumes for bb8, and invokes the built image to dump out the SSH key and
 known hosts file that will be required for the rsync container.
 
 # Using bb8
-You can invoke the image built by setup.sh with the `./bb8` wrapper script. e.g.
+You can invoke the image built by setup with the `./bb8` wrapper script. e.g.
 
 ```
-./bb8 backup
+bb8 backup
 ```
 
 or to see all options, just:
 
 ```
-./bb8
+bb8
 ```
 
 ## Schedule backups

--- a/schedule
+++ b/schedule
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+contents = "@hourly root bb8 backup # BB8 backup"
+path = "/etc/cron.d/bb8"
+
+with open(path, 'r') as f:
+    current = f.read()
+
+if current == contents:
+    print("Backup already scheduled")
+else:
+    with open(path, 'w') as f:
+        f.write(contents)
+    print("Scheduled hourly backups ☺️")

--- a/schedule
+++ b/schedule
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-contents = "@hourly root bb8 backup # BB8 backup"
+contents = "@hourly root bb8 backup # BB8 backup\n"
 path = "/etc/cron.d/bb8"
 
 with open(path, 'r') as f:

--- a/schedule.sh
+++ b/schedule.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -ex
-echo "root bb8 backup # BB8 backup" > /etc/cron.d/bb8
-echo "Scheduled hourly backups ☺️"

--- a/setup
+++ b/setup
@@ -2,7 +2,7 @@
 set -e
 
 if [[ ($# -eq 0) ]]; then
-    echo "Usage: ./setup.sh PATH_TO_SOURCE_CONFIG [TARGET ...]"
+    echo "Usage: ./setup PATH_TO_SOURCE_CONFIG [TARGET ...]"
     exit -1;
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -28,10 +28,18 @@ docker build --build-arg "TARGETS=$targets" --tag bb8 .
 docker volume create bb8_ssh
 docker volume create bb8_logs
 ${HERE}/bb8 init
-ln -sf $(realpath ${HERE}/bb8) /usr/local/bin/bb8
+
+# Setup link
+path=$(realpath ${HERE}/bb8)
+link_path=/usr/local/bin/bb8
+link_status=$(readlink -- $link_path)
+if [ "$link_status" != "$path" ]; then
+    echo "Creating symlink at $link_path"
+    ln -sf $path $link_path
+fi
 
 echo "-----------------------------------------------"
 echo "Setup complete. You can now: "
 echo "backup:           Run bb8 backup"
 echo "restore:          Run bb8 restore"
-echo "schedule backups: Run sudo ./schedule.sh"
+echo "schedule backups: Run sudo ./schedule"

--- a/testing/test-setup.sh
+++ b/testing/test-setup.sh
@@ -14,4 +14,4 @@ docker build --rm -t $IMAGE_NAME $HERE
 docker run --rm -v ${BB8_ROOT}:/src \
        -e VAULT_AUTH_GITHUB_TOKEN=$VAULT_AUTH_GITHUB_TOKEN \
        $IMAGE_NAME \
-       /src/setup.sh
+       /src/setup


### PR DESCRIPTION
This is part of https://vimc.myjetbrains.com/youtrack/issue/VIMC-1682

Since the deploy tool will be running bb8 tasks every deploy, my aim here is to make it so that we only require root if absolutely necessary, so as to avoid always having to run Montagu deploy as root.

The two parts of bb8 set up that require root are creating the symlink to /usr/local/bin and writing to cron.hourly.

I wanted to make the code smart enough that if we changed things it would want to update the files on the OS automatically, not just check to see if they already exist. So `schedule` becomes a short python script once more which actually checks the contents of the cron file to make sure it exactly matches. Similarly, but more simply, the `setup.sh` script actually checks that the symlink is pointing to the right place.