### PR TITLE
i1664: Warnings and better JSON output

### DIFF
--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -5,7 +5,7 @@ from bin.bb8.status import interpret_timestamp_output
 
 def test_that_empty_timestamp_is_interpreted_as_missing_data():
     x = interpret_timestamp_output("".encode("utf-8"))
-    assert x == "No files present"
+    assert x is None
 
 
 def test_that_timestamp_is_correctly_parsed_and_zoned():
@@ -13,4 +13,4 @@ def test_that_timestamp_is_correctly_parsed_and_zoned():
     # Going from +2 to -5 timezone
     x = interpret_timestamp_output(input.encode("utf-8"),
                                    timezone=timezone("America/Jamaica"))
-    assert x == "2018-05-18 08:00:00-05:00"
+    assert x.isoformat(" ") == "2018-05-18 08:00:00-05:00"


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1664

This makes the JSON output more machine readable, as it now returns `null` where the timestamp is missing, instead of human readable text.

And it improves the human readable output so that it prints out warnings if backup or restore need running.