### PR TITLE
if instance_guid doesn't exist, set to None

### DIFF
--- a/bin/bb8/remote_file_manager.py
+++ b/bin/bb8/remote_file_manager.py
@@ -56,7 +56,7 @@ class RemoteFileManager(object):
 
     def validate_instance(self, local_guid):
         metadata = self.get_metadata()
-        remote_guid = metadata["instance_guid"]
+        remote_guid = metadata.get("instance_guid", None)
         if remote_guid and local_guid and remote_guid != local_guid:
             raise Exception("Target {} has been backed up by a different "
                             "instance of bb8.".format(self.paths.target_name))


### PR DESCRIPTION
Fixes an error running the new bb8 code against a starport which doesn't yet include the new metadata. 
`KeyError: 'instance_guid'` 
