### PR TITLE
mount machine-id to use as instance guid

### DIFF
--- a/bb8
+++ b/bb8
@@ -13,6 +13,7 @@ docker run \
     --rm \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v bb8_ssh:/bb8/etc/.ssh \
+    -v /etc/machine-id:/bb8/etc/machine-id \
     -v bb8_logs:/bb8/logs \
     -v /etc/timezone:/etc/timezone:ro \
     --name $container_name \

--- a/bin/bb8/settings.py
+++ b/bin/bb8/settings.py
@@ -1,5 +1,5 @@
 import json
-from os.path import join, abspath
+from os.path import join, isfile
 
 from .targets import DirectoryTarget, NamedVolumeTarget, TargetOptions
 
@@ -9,6 +9,7 @@ config_path = join(root_path, "config.json")
 ssh_key_path = join(root_path, "secrets/ssh_key")
 host_key_path = join(root_path, "secrets/host_key")
 known_hosts_path = join(root_path, "known_hosts")
+machine_id_path = join(root_path, "machine-id")
 
 log_dir = '/bb8/logs/'
 
@@ -21,8 +22,9 @@ class Settings:
         self.starport = config["starport"]
         self.targets = list(Settings.parse_target(t) for t in config["targets"])
 
-        if "instance_guid" in config:
-            self.instance_guid = config["instance_guid"]
+        if isfile(machine_id_path):
+            with open(machine_id_path, 'r') as f:
+                self.instance_guid = f.read().replace('\n', '')
         else:
             self.instance_guid = None
 

--- a/bin/setup.py
+++ b/bin/setup.py
@@ -3,7 +3,6 @@
 Usage:
   setup.py [TARGET ...]
 """
-import uuid
 
 from docopt import docopt
 
@@ -30,11 +29,9 @@ def setup_targets():
         config = json.load(f)
     check_user_input(config, desired_targets)
     machine_targets = list(x for x in config["targets"] if x["name"] in desired_targets)
-    instance_guid = str(uuid.uuid4())
     machine_config = {
         'starport': config["starport"],
-        'targets': machine_targets,
-        'instance_guid': instance_guid
+        'targets': machine_targets
     }
     with open(config_path, 'w') as f:
         json.dump(machine_config, f, indent=4)


### PR DESCRIPTION
This leaves the targets config as build into the container, but mounts the machine-id to use as instance guid.

After merging should update https://github.com/vimc/montagu-bb8 to point the submodule to the latest code.