### PR TITLE
i2551: restart rsync on failure

### DIFF
--- a/bin/bb8/docker_rsync.py
+++ b/bin/bb8/docker_rsync.py
@@ -86,7 +86,8 @@ class DockerRsync(object):
 
         logging.info("Backing up to {} from {}".format(remote_path,
                                                        local_volume))
-        self._run_rsync(volumes, local_volume, remote_path, relative=True)
+        self._run_rsync_with_restart(volumes, local_volume, remote_path,
+                                     relative=True)
 
     def restore_volume(self, local_volume, remote_path):
         mounted_volume = join("/", local_volume)
@@ -96,7 +97,8 @@ class DockerRsync(object):
 
         logging.info("Restoring from {} to {}".format(remote_path,
                                                       local_volume))
-        self._run_rsync(volumes, remote_path, mounted_volume, relative=False)
+        self._run_rsync_with_restart(volumes, remote_path, mounted_volume,
+                                     relative=False)
 
 
 class RsyncError(Exception):

--- a/bin/bb8/docker_rsync.py
+++ b/bin/bb8/docker_rsync.py
@@ -69,7 +69,7 @@ class DockerRsync(object):
             except RsyncError as e:
                 print(str(e), flush=True)
                 attempts += 1
-                if attempts >= restarts:
+                if attempts > restarts:
                     raise Exception("rsync failed too many times")
                 print("trying again... {}/{}".format(attempts, restarts),
                       flush=True)

--- a/bin/bb8/docker_rsync.py
+++ b/bin/bb8/docker_rsync.py
@@ -67,11 +67,12 @@ class DockerRsync(object):
                 self._run_rsync(volumes, from_path, to_path, relative)
                 done = True
             except RsyncError as e:
-                print(str(e))
+                print(str(e), flush=True)
                 attempts += 1
-                if attempts > restarts:
+                if attempts >= restarts:
                     raise Exception("rsync failed too many times")
-                print("trying again... {}/{}".format(attempts, restarts))
+                print("trying again... {}/{}".format(attempts, restarts),
+                      flush=True)
 
     def _get_volume_args(self, local_volume, volume_mode):
         mounted_volume = join("/", local_volume)


### PR DESCRIPTION
See https://vimc.myjetbrains.com/youtrack/issue/VIMC-2551 for rationale

This does two things:

* propagate container failure to the controlling python process so that we don't continue after rsync failure
* have a few goes before giving up, in the case of network failure