### PR TITLE
vimc-4232 add buildkite pipeline

### DIFF
--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: ":mag: Run tests"
+    command: buildkite/test.sh

--- a/buildkite/test.sh
+++ b/buildkite/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+docker build -f tests/Dockerfile --tag bb8_tests .
+docker run --rm \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    bb8_tests

--- a/teamcity.sh
+++ b/teamcity.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-docker build -f tests/Dockerfile --tag bb8_tests .
-docker run --rm \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    bb8_tests

--- a/tests/test_remote_file_manager.py
+++ b/tests/test_remote_file_manager.py
@@ -65,14 +65,14 @@ class TestRemoteFileManager(object):
 
     def test_validate_instance_raises_exception_if_mismatched(self):
         # Setup
-        sut = RemoteFileManager(Dynamic("paths"))
+        sut = RemoteFileManager(Dynamic("paths", target_name="fake-target", starport="fake-starport"))
         sut.get_metadata = lambda: {
             "instance_guid": "foreign_guid"
         }
 
         # Test
-        expected_message = "This target has been backed up by a different " \
-                           "instance of bb8: target"
+        expected_message = "Target fake-target has been backed up by a different " \
+                           "instance of bb8"
         with pytest.raises(Exception, match = expected_message):
             sut.validate_instance("local_guid")
 

--- a/tests/test_remote_file_manager.py
+++ b/tests/test_remote_file_manager.py
@@ -73,7 +73,7 @@ class TestRemoteFileManager(object):
         # Test
         expected_message = "This target has been backed up by a different " \
                            "instance of bb8: target"
-        with pytest.raises(Exception, message=expected_message):
+        with pytest.raises(Exception, match = expected_message):
             sut.validate_instance("local_guid")
 
     def test_validate_instance_passes_if_matched(self):


### PR DESCRIPTION
This PR 
* adds a builkite pipeline
* removes the teamcity script
* updates a test to remove a deprecated pytest option, which lead me to discover we were using that pytest option wrong (we had made the exact mistake that pytest cite as their reason for deprecating the option! https://docs.pytest.org/en/stable/deprecations.html#message-parameter-of-pytest-raises) - once the pytest syntax was fixed, the test actually failed, so that is fixed here as well